### PR TITLE
[ADD] custom entrypoints

### DIFF
--- a/entrypoint.d/000-custom-config
+++ b/entrypoint.d/000-custom-config
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import logging
+_logger = logging.getLogger(__name__)
+
+RESOURCES = os.environ.get('RESOURCES')
+CUSTOM_CONFIG = os.environ.get('CUSTOM_CONFIG')
+
+if CUSTOM_CONFIG:
+    _logger.info('Adding entrypoint configuration:\n%s' % CUSTOM_CONFIG)
+    config_file = os.path.join(RESOURCES, 'conf.d', '999-entrypoint.conf')
+    with open(config_file, 'w+') as file:
+        file.write(CUSTOM_CONFIG)

--- a/entrypoint.d/000-custom-requirements
+++ b/entrypoint.d/000-custom-requirements
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import subprocess
+import logging
+_logger = logging.getLogger(__name__)
+
+RESOURCES = os.environ.get('RESOURCES')
+CUSTOM_REQUIREMENTS = os.environ.get('CUSTOM_REQUIREMENTS')
+
+if CUSTOM_REQUIREMENTS:
+    _logger.info('Installing custom pip requirements...')
+    # Save custom entrypoint to local file
+    custom_file = os.path.join(RESOURCES, 'xxx-custom-pip-requirements.txt')
+    with open(custom_file, 'w+') as file:
+        file.write(CUSTOM_REQUIREMENTS)
+    # Execute custom entrypoint
+    subprocess.check_call([
+        'pip',
+        'install',
+        '--user',
+        '--no-cache-dir',
+        '-r',
+        custom_file,
+    ])
+    # Cleanup
+    os.remove(custom_file)

--- a/entrypoint.d/900-custom-entrypoint
+++ b/entrypoint.d/900-custom-entrypoint
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import stat
+import subprocess
+import logging
+_logger = logging.getLogger(__name__)
+
+RESOURCES = os.environ.get('RESOURCES')
+CUSTOM_ENTRYPOINT = os.environ.get('CUSTOM_ENTRYPOINT')
+
+if CUSTOM_ENTRYPOINT:
+    _logger.info('Executing custom entrypoint...')
+    # Save custom entrypoint to local file
+    custom_entrypoint = os.path.join(RESOURCES, 'xxx-custom-entrypoint')
+    with open(custom_entrypoint, 'w+') as file:
+        file.write(CUSTOM_ENTRYPOINT)
+    # Make file executable
+    st = os.stat(custom_entrypoint)
+    os.chmod(custom_entrypoint, st.st_mode | stat.S_IEXEC)
+    # Execute custom entrypoint
+    subprocess.check_call(custom_entrypoint, cwd='/home/odoo')
+    # Cleanup
+    os.remove(custom_entrypoint)


### PR DESCRIPTION
@jjscarafia esta PR reemplaza a https://github.com/ingadhoc/docker-odoo-saas-project/pull/3

Estos dos entrypoints son particularmente utiles para desarrollo local.
Los estoy usando en algunos proyectos donde por algún que otro motivo hay que resolver algunas cosas antes de levantar la imagen, por ej: openupgrade.

Se podría integrar con saas_provider y rancher-catalog, especialmente el de requirements.txt. Ya me ha pasado que por agregar repos custom de algun proyecto que no tiene bien definido el requirements.txt, tengo que andar haciendo cosas raras.

También traigo el custom_config entrypoint para acá