### PR TITLE
[REM] Deprecate env DATABASE in favour of PGDATABASE

### DIFF
--- a/conf.d/20-database.conf
+++ b/conf.d/20-database.conf
@@ -1,10 +1,10 @@
 [options]
 ; Database settings, matching defaults when you execute `psql`
-db_user = $PGUSER
-db_password = $PGPASSWORD
 db_host = $PGHOST
 db_port = $PGPORT
+db_name = $PGDATABASE
+db_user = $PGUSER
+db_password = $PGPASSWORD
 db_template = $DB_TEMPLATE
-db_name = $DATABASE
 dbfilter = $DBFILTER
 list_db = $LIST_DB

--- a/entrypoint.d/700-fix-dbs
+++ b/entrypoint.d/700-fix-dbs
@@ -3,13 +3,13 @@ set -e
 
 # Add the unaccent module for the database if needed
 # Fail silently, because database may not exist
-if [ "${UNACCENT,,}" == "true" ] && [ "${DATABASE,,}" != "" ]; then
+if [ "${UNACCENT,,}" == "true" ] && [ "${PGDATABASE,,}" != "" ]; then
     echo Trying to install unaccent extension > /dev/stderr
-    ! psql -d "$DATABASE" -c 'CREATE EXTENSION IF NOT EXISTS unaccent;'
+    ! psql -c 'CREATE EXTENSION IF NOT EXISTS unaccent;'
 fi
 
 # Update modules
-if [ "${FIXDBS,,}" == "true" ] && [ "${DATABASE,,}" != "" ]; then
+if [ "${FIXDBS,,}" == "true" ] && [ "${PGDATABASE,,}" != "" ]; then
     echo Trying to fix databases > /dev/stderr
     click-odoo-update --if-exists --watcher-max-seconds ${CLICK_ODOO_UPDATE_WATCHER_MAX_SECONDS-30}
 fi


### PR DESCRIPTION
@jjscarafia deprecar variable de entorno `DATABASE`, total ya estamos mandando `PGDATABASE` que funciona también con `psql`
