### PR TITLE
[IMP] Remove odoo.yml and odoo-e.yml. Make ODOO_SOURCE configurable via env var

### DIFF
--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -161,8 +161,7 @@ RUN pip install --user Werkzeug==0.14.1
 #
 
 FROM base AS odoo
-COPY odoo.yml $RESOURCES/
-RUN autoaggregate --config "$RESOURCES/odoo.yml" --install --output $SOURCES
+RUN git clone --single-branch --depth 1 --branch $ODOO_VERSION https://github.com/$ODOO_SOURCE $SOURCES/odoo
 RUN pip install --user --no-cache-dir $SOURCES/odoo
 
 #
@@ -174,5 +173,4 @@ ARG GITHUB_USER
 ARG GITHUB_TOKEN
 ENV GITHUB_USER="$GITHUB_USER"
 ENV GITHUB_TOKEN="$GITHUB_TOKEN"
-COPY odoo-e.yml $RESOURCES/
-RUN autoaggregate --config "$RESOURCES/odoo-e.yml" --install --output $SOURCES
+RUN git clone --single-branch --depth 1 --branch $ODOO_VERSION https://$GITHUB_USER:$GITHUB_TOKEN@github.com/odoo/enterprise.git $SOURCES/enterprise

--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -76,6 +76,7 @@ RUN gem install --no-rdoc --no-ri --no-update-sources bootstrap-sass --version '
 # This is at the end to benefit from cache at build time
 # https://docs.docker.com/engine/reference/builder/#/impact-on-build-caching
 ARG ODOO_SOURCE=odoo/odoo
+ENV ODOO_SOURCE="$ODOO_SOURCE"
 ARG ODOO_VERSION=11.0
 ENV ODOO_VERSION="$ODOO_VERSION"
 RUN debs="libldap2-dev libsasl2-dev" \

--- a/12.0.Dockerfile
+++ b/12.0.Dockerfile
@@ -157,8 +157,7 @@ RUN pip install --user Werkzeug==0.14.1
 #
 
 FROM base AS odoo
-COPY odoo.yml $RESOURCES/
-RUN autoaggregate --config "$RESOURCES/odoo.yml" --install --output $SOURCES
+RUN git clone --single-branch --depth 1 --branch $ODOO_VERSION https://github.com/$ODOO_SOURCE $SOURCES/odoo
 RUN pip install --user --no-cache-dir $SOURCES/odoo
 
 #
@@ -170,5 +169,4 @@ ARG GITHUB_USER
 ARG GITHUB_TOKEN
 ENV GITHUB_USER="$GITHUB_USER"
 ENV GITHUB_TOKEN="$GITHUB_TOKEN"
-COPY odoo-e.yml $RESOURCES/
-RUN autoaggregate --config "$RESOURCES/odoo-e.yml" --install --output $SOURCES
+RUN git clone --single-branch --depth 1 --branch $ODOO_VERSION https://$GITHUB_USER:$GITHUB_TOKEN@github.com/odoo/enterprise.git $SOURCES/enterprise

--- a/12.0.Dockerfile
+++ b/12.0.Dockerfile
@@ -72,6 +72,7 @@ RUN ln -s /usr/bin/nodejs /usr/local/bin/node \
 # This is at the end to benefit from cache at build time
 # https://docs.docker.com/engine/reference/builder/#/impact-on-build-caching
 ARG ODOO_SOURCE=odoo/odoo
+ENV ODOO_SOURCE="$ODOO_SOURCE"
 ARG ODOO_VERSION=12.0
 ENV ODOO_VERSION="$ODOO_VERSION"
 RUN debs="libldap2-dev libsasl2-dev" \

--- a/13.0.Dockerfile
+++ b/13.0.Dockerfile
@@ -167,8 +167,7 @@ RUN pip install --user Werkzeug==0.14.1
 #
 
 FROM base AS odoo
-COPY odoo.yml $RESOURCES/
-RUN autoaggregate --config "$RESOURCES/odoo.yml" --install --output $SOURCES
+RUN git clone --single-branch --depth 1 --branch $ODOO_VERSION https://github.com/$ODOO_SOURCE $SOURCES/odoo
 RUN pip install --user --no-cache-dir $SOURCES/odoo
 
 #
@@ -180,5 +179,4 @@ ARG GITHUB_USER
 ARG GITHUB_TOKEN
 ENV GITHUB_USER="$GITHUB_USER"
 ENV GITHUB_TOKEN="$GITHUB_TOKEN"
-COPY odoo-e.yml $RESOURCES/
-RUN autoaggregate --config "$RESOURCES/odoo-e.yml" --install --output $SOURCES
+RUN git clone --single-branch --depth 1 --branch $ODOO_VERSION https://$GITHUB_USER:$GITHUB_TOKEN@github.com/odoo/enterprise.git $SOURCES/enterprise

--- a/13.0.Dockerfile
+++ b/13.0.Dockerfile
@@ -66,6 +66,7 @@ RUN apt-get -qq update \
     && sync
 
 ARG ODOO_SOURCE=odoo/odoo
+ENV ODOO_SOURCE="$ODOO_SOURCE"
 ARG ODOO_VERSION=13.0
 ENV ODOO_VERSION="$ODOO_VERSION"
 

--- a/8.0.Dockerfile
+++ b/8.0.Dockerfile
@@ -82,6 +82,7 @@ RUN gem install --no-rdoc --no-ri --no-update-sources bootstrap-sass --version '
 # This is at the end to benefit from cache at build time
 # https://docs.docker.com/engine/reference/builder/#/impact-on-build-caching
 ARG ODOO_SOURCE=odoo/odoo
+ENV ODOO_SOURCE="$ODOO_SOURCE"
 ARG ODOO_VERSION=8.0
 ENV ODOO_VERSION="$ODOO_VERSION"
 RUN debs="python-dev build-essential libxml2-dev libxslt1-dev libjpeg-dev libfreetype6-dev liblcms2-dev libopenjpeg-dev libtiff5-dev tk-dev tcl-dev linux-headers-amd64 libpq-dev libldap2-dev libsasl2-dev" \

--- a/8.0.Dockerfile
+++ b/8.0.Dockerfile
@@ -159,8 +159,7 @@ RUN pip install --user Werkzeug==0.14.1
 #
 
 FROM base AS odoo
-COPY odoo.yml $RESOURCES/
-RUN autoaggregate --config "$RESOURCES/odoo.yml" --install --output $SOURCES
+RUN git clone --single-branch --depth 1 --branch $ODOO_VERSION https://github.com/$ODOO_SOURCE $SOURCES/odoo
 RUN pip install --user --no-cache-dir $SOURCES/odoo
 
 # Simulate odoo bin
@@ -175,5 +174,5 @@ ARG GITHUB_USER
 ARG GITHUB_TOKEN
 ENV GITHUB_USER="$GITHUB_USER"
 ENV GITHUB_TOKEN="$GITHUB_TOKEN"
-COPY odoo-e.yml $RESOURCES/
-RUN autoaggregate --config "$RESOURCES/odoo-e.yml" --install --output $SOURCES
+RUN git clone --single-branch --depth 1 --branch $ODOO_VERSION https://$GITHUB_USER:$GITHUB_TOKEN@github.com/odoo/enterprise.git $SOURCES/enterprise
+

--- a/hooks/build
+++ b/hooks/build
@@ -30,6 +30,7 @@ for target in base odoo enterprise; do
         --file "$DOCKER_TAG.Dockerfile" \
         --build-arg VCS_REF="$GIT_SHA1" \
         --build-arg BUILD_DATE="$(date --rfc-3339 ns)" \
+        --build-arg ODOO_SOURCE="${ODOO_SOURCE-odoo/odoo}" \
         --build-arg ODOO_VERSION="$DOCKER_TAG" \
         --build-arg GITHUB_USER="$GITHUB_USER" \
         --build-arg GITHUB_TOKEN="$GITHUB_TOKEN" \

--- a/odoo-e.yml
+++ b/odoo-e.yml
@@ -1,9 +1,0 @@
-
-enterprise:
-    defaults: 
-        depth: 1
-    remotes:
-        odoo: https://$GITHUB_USER:$GITHUB_TOKEN@github.com/odoo/enterprise.git
-    merges:
-        - odoo $ODOO_VERSION
-    target: odoo $ODOO_VERSION

--- a/odoo.yml
+++ b/odoo.yml
@@ -1,9 +1,0 @@
-
-odoo:
-    defaults:
-        depth: 1
-    remotes:
-        odoo: https://github.com/odoo/odoo.git
-    merges:
-        - odoo $ODOO_VERSION
-    target: odoo $ODOO_VERSION


### PR DESCRIPTION
@jjscarafia 

**Remover el odoo.yml y odoo-e.yml**
No tiene sentido si sólo van a clonar un repositorio.
Tampoco tenía sentido porque nunca vamos a mezclar cosas en esta capa de las imagenes. Si llegasemos a mezclar PRs abiertas a odoo, lo haríamos en el docker-odoo-saas-project, de alguna manera.

**Consumir ODOO_SOURCE env var**
Por defecto apunta a odoo/odoo, pero si esta variable está establecida se usará como repositorio de odoo.
Esto permite construir imágenes de OCA/OCB, o de OCA/openupgrade (https://hub.docker.com/repository/docker/druidoo/openupgrade)

Particularmente me interesa la de openupgrade, que ya la tengo andando haciendo build desde este branch


