### PR TITLE
[IMP] avoid template1 env var so that default variable is used

### DIFF
--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -28,8 +28,7 @@ ENV ODOO_SERVER=odoo \
     PGPASSWORD=odoo \
     PGHOST=db \
     PGPORT=5432 \
-    ADMIN_PASSWORD=admin \
-    DB_TEMPLATE=template1
+    ADMIN_PASSWORD=admin
 
 # Other requirements and recommendations to run Odoo
 # See https://github.com/$ODOO_SOURCE/blob/$ODOO_VERSION/debian/control

--- a/12.0.Dockerfile
+++ b/12.0.Dockerfile
@@ -28,8 +28,7 @@ ENV ODOO_SERVER=odoo \
     PGPASSWORD=odoo \
     PGHOST=db \
     PGPORT=5432 \
-    ADMIN_PASSWORD=admin \
-    DB_TEMPLATE=template1
+    ADMIN_PASSWORD=admin
 
 # Other requirements and recommendations to run Odoo
 # See https://github.com/$ODOO_SOURCE/blob/$ODOO_VERSION/debian/control

--- a/13.0.Dockerfile
+++ b/13.0.Dockerfile
@@ -28,8 +28,7 @@ ENV ODOO_SERVER=odoo \
     PGPASSWORD=odoo \
     PGHOST=db \
     PGPORT=5432 \
-    ADMIN_PASSWORD=admin \
-    DB_TEMPLATE=template1
+    ADMIN_PASSWORD=admin
 
 # Other requirements and recommendations to run Odoo
 # See https://github.com/$ODOO_SOURCE/blob/$ODOO_VERSION/debian/control

--- a/8.0.Dockerfile
+++ b/8.0.Dockerfile
@@ -28,8 +28,7 @@ ENV ODOO_SERVER=odoo \
     PGPASSWORD=odoo \
     PGHOST=db \
     PGPORT=5432 \
-    ADMIN_PASSWORD=admin \
-    DB_TEMPLATE=template1
+    ADMIN_PASSWORD=admin
 
 # Other requirements and recommendations to run Odoo
 # See https://github.com/$ODOO_SOURCE/blob/$ODOO_VERSION/debian/control


### PR DESCRIPTION
This is related to this https://github.com/odoo/odoo/commit/3edd504f17a2fe435ccd8235037e96c11ba96c18