### PR TITLE
[FIX] use DOCKERFILE_PATH

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -27,7 +27,7 @@ for target in base odoo enterprise; do
     fi
 
     docker image build \
-        --file "$DOCKER_TAG.Dockerfile" \
+        --file "$DOCKERFILE_PATH" \
         --build-arg VCS_REF="$GIT_SHA1" \
         --build-arg BUILD_DATE="$(date --rfc-3339 ns)" \
         --build-arg ODOO_VERSION="$DOCKER_TAG" \


### PR DESCRIPTION
Buenas @ivantodorovich 
Te parece bien este cambio?
1. por ahí queda un poco mas prolijo haciendo que el parámetro "Dockerfile location" tenga un uso (hoy se sobreescribe)
2. permite, por ejemplo, usar el dockerfile de 13 para construir master ( o cualquier saas13- algo) sin necesidad de hacer cambios en el repo

![image](https://user-images.githubusercontent.com/3016656/87145887-799a9e00-c280-11ea-96f5-c26cf4b74010.png)

