### PR TITLE
[IMP] install odoo as editable

### DIFF
--- a/13.0.Dockerfile
+++ b/13.0.Dockerfile
@@ -170,7 +170,7 @@ RUN pip install --user Werkzeug==0.14.1
 
 FROM base AS odoo
 RUN git clone --single-branch --depth $ODOO_SOURCE_DEPTH --branch $ODOO_VERSION https://github.com/$ODOO_SOURCE $SOURCES/odoo
-RUN pip install --user -e $SOURCES/odoo
+RUN pip install --user --no-cache-dir -e $SOURCES/odoo
 
 #
 #   Odoo Enterprise

--- a/13.0.Dockerfile
+++ b/13.0.Dockerfile
@@ -170,7 +170,7 @@ RUN pip install --user Werkzeug==0.14.1
 
 FROM base AS odoo
 RUN git clone --single-branch --depth $ODOO_SOURCE_DEPTH --branch $ODOO_VERSION https://github.com/$ODOO_SOURCE $SOURCES/odoo
-RUN pip install --user --no-cache-dir $SOURCES/odoo
+RUN pip install --user -e $SOURCES/odoo
 
 #
 #   Odoo Enterprise


### PR DESCRIPTION
when using -e on pip install the project is installed on editable mode, wihtout making a copy of any file to /home/odoo/.local/lib/python3.7/site-packages/odoo/

With this we should win three things:
* little less image size (Because no files are copied)
* if in a repos.yml on top images, we update odoo instance, the code of the odoo addons could not be "syncked" to the code of the odoo server. We have face an error due to this on v13 where the definition of a method was changed on tools/mail.py and on mail module, if you only pull odoo then this is a problem, another solution would be reinstalling after any odoo pull
* on dev, it's easier to debug and play with the /home/odoo/src/odoo/odoo directory because it's mounted as a local volume

