### PR TITLE
[FIX] pip: pip for python 3.5 (and 2.7) url has changed

### DIFF
--- a/12.0.Dockerfile
+++ b/12.0.Dockerfile
@@ -51,7 +51,7 @@ RUN apt-get -qq update \
         sudo \
     && echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
     && curl -SL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
-    && curl https://bootstrap.pypa.io/get-pip.py | python3 /dev/stdin \
+    && curl https://bootstrap.pypa.io/pip/3.5/get-pip.py | python3 /dev/stdin \
     && curl -sL https://deb.nodesource.com/setup_8.x | bash - \
     && apt-get update \
     && apt-get install -yqq --no-install-recommends nodejs postgresql-client \


### PR DESCRIPTION
From https://github.com/Tecnativa/doodba/commit/841cf3fb43e897b9f6ae8c7b01b1b3d3a7b1f030